### PR TITLE
Show bug when using visit() instead of visit*()

### DIFF
--- a/src/evaluator/Standard.java
+++ b/src/evaluator/Standard.java
@@ -3,6 +3,7 @@ package evaluator;
 import environment.Environment;
 import environment.UnboundVariable;
 import expression.binary.Binary;
+import expression.binary.Plus;
 import expression.conditional.If;
 import expression.atomic.*;
 
@@ -18,10 +19,18 @@ public class Standard {
 
 	public int visit(Binary expression, Environment env) throws UnboundVariable {
 		int x = expression.getOperand(1).eval(this, env);
+                System.out.println("visit(Binary)");
 		int y = expression.getOperand(2).eval(this, env);
 		return expression.compute(x, y);
 	}
 	
+public int visit(Plus expression, Environment env) throws UnboundVariable {
+  System.out.println("visit(Plus)");
+  int x = expression.getOperand(1).eval(this, env);
+  int y = expression.getOperand(2).eval(this, env);
+  return x + y;
+}
+
 	public int visit(If expression, Environment env) throws UnboundVariable {
 		if (expression.getCondition().eval(this, env) == 1) {
 			return expression.getInstruction(1).eval(this, env);			

--- a/src/expression/binary/Plus.java
+++ b/src/expression/binary/Plus.java
@@ -1,5 +1,8 @@
 package expression.binary;
 
+import environment.Environment;
+import environment.UnboundVariable;
+import evaluator.Standard;
 import expression.Expression;
 
 public class Plus extends Binary {
@@ -12,4 +15,8 @@ public class Plus extends Binary {
 	public int compute(int x, int y) {
 		return x + y;
 	}
+  @Override
+  public <E extends Standard> int eval(E evaluator, Environment env) throws UnboundVariable {
+    return evaluator.visit(this, env);
+  }
 }

--- a/src/main/Main.java
+++ b/src/main/Main.java
@@ -1,6 +1,7 @@
 package main;
 
 import environment.*;
+import evaluator.Standard;
 import expression.*;
 import expression.atomic.*;
 import expression.binary.*;
@@ -8,7 +9,11 @@ import expression.conditional.If;
 
 public class Main {
 
-	public static void main (String[] args) {
+  public static void main(String[] args) throws UnboundVariable {
+    Binary binary = new Plus(new Literal(3), new Literal(5));
+    new Standard().visit(binary, new Environment());
+  }
+	public static void main2 (String[] args) {
 		int result = 0;
 		Environment env = new Environment();
 		Expression e = createExpression(env);


### PR DESCRIPTION
This small patch shows how easy it is to confuse the average Java developer with simple code. If you apply this patch and run the new `main()`, you will see `visit(Binary)` instead of `visit(Plus)` as could be expected with such simple code:

``` java
  public static void main(String[] args) throws UnboundVariable {
    Binary binary = new Plus(new Literal(3), new Literal(5));
    new Standard().visit(binary, new Environment());
  }
```

When the static type takes precedence over the dynamic type, you start getting troubles.
